### PR TITLE
do not throw errors for new buffers

### DIFF
--- a/org-roam-timestamps.el
+++ b/org-roam-timestamps.el
@@ -103,7 +103,7 @@ Defaults to one hour."
 Optionally checks the minimum time interval you want between mod times
 if you supply the current MTIME."
   (org-with-wide-buffer
-   (let ((pos (if node (org-roam-node-point node) (point-marker)))
+   (let ((pos (if node (org-roam-node-point node) (point-min)))
          (curr (org-roam-timestamps-decode (current-time))))
      (if (and org-roam-timestamps-remember-timestamps mtime)
          (when (> (org-roam-timestamps-subtract curr mtime t) org-roam-timestamps-minimum-gap)
@@ -113,7 +113,7 @@ if you supply the current MTIME."
 (defun org-roam-timestamps--get-mtime (node)
   "Get the mtime of the org-roam node NODE."
   (org-with-wide-buffer
-   (org-entry-get (if node (org-roam-node-point node) (point-marker)) "mtime")))
+   (org-entry-get (if node (org-roam-node-point node) (point-min)) "mtime")))
 
 (defun org-roam-timestamps--get-ctime (pos)
   "Return the current ctime for the node at point POS."

--- a/org-roam-timestamps.el
+++ b/org-roam-timestamps.el
@@ -113,7 +113,7 @@ if you supply the current MTIME."
 (defun org-roam-timestamps--get-mtime (node)
   "Get the mtime of the org-roam node NODE."
   (org-with-wide-buffer
-   (org-entry-get (org-roam-node-point node) "mtime")))
+   (org-entry-get (if node (org-roam-node-point node) (point-marker)) "mtime")))
 
 (defun org-roam-timestamps--get-ctime (pos)
   "Return the current ctime for the node at point POS."

--- a/org-roam-timestamps.el
+++ b/org-roam-timestamps.el
@@ -103,7 +103,7 @@ Defaults to one hour."
 Optionally checks the minimum time interval you want between mod times
 if you supply the current MTIME."
   (org-with-wide-buffer
-   (let ((pos (org-roam-node-point node))
+   (let ((pos (if node (org-roam-node-point node) (point-marker)))
          (curr (org-roam-timestamps-decode (current-time))))
      (if (and org-roam-timestamps-remember-timestamps mtime)
          (when (> (org-roam-timestamps-subtract curr mtime t) org-roam-timestamps-minimum-gap)


### PR DESCRIPTION
Closes #13.

Should fix #13 as well as a new, related error that comes up when loading org-roam-timestamp from a new template on boot.

I think the code would be more simple if you require passing in a position to these functions as opposed to nodes (like with ctime). I didn't do this because I don't really work in elisp and didn't want to break anything. To that extent, I would love it if someone would validate that this is, indeed, solving #13 . My testing strategy is ad-hoc and unstable. 

It is possible that #13 is a dupe of #10, which should have been reopened. 